### PR TITLE
route: DamageTable: lookup EVs for current level

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The content within the square brackets is displayed as a header above the table,
 
 `evolution` (number, default: `0`) - The evolution of the runner's Pokémon at the time of the attack, zero-indexed.
 
-`evs` (number, default: `0`) - The EVs in the relevant stat of the runner's Pokémon at the time of the attack.
+`evs` (number, default: `0`) - The EVs in the relevant stat of the runner's Pokémon at the time of the attack. When no EVs are specified, the EVs from the IV tracker for the given level will be used if available.
 
 `combatStages` (number, default: `0`) - The number of combat stages in the relevant stat of the runner's Pokémon at the time of the attack.
 

--- a/components/route/DamageTable.tsx
+++ b/components/route/DamageTable.tsx
@@ -125,7 +125,7 @@ export const DamageTable: React.FC<DamageTableProps> = ({
     }
 
     return filterToStatRange(combineIdenticalLines(ranges), natureSet, relevantStat, ivRanges[relevantStat]);
-  }, [baseStats, ivRanges, confirmedNature, relevantStat, level, offensive, evs, combatStages, movePower, effectiveness, stab, opponentStat, opponentCombatStages, torrent, weatherBoosted, weatherReduced, multiTarget, otherModifier, friendship, opponentLevel, healthThreshold, source, state.trackers]);
+  }, [baseStats, ivRanges, confirmedNature, relevantStat, level, offensive, trackerEvs, combatStages, movePower, effectiveness, stab, opponentStat, opponentCombatStages, torrent, weatherBoosted, weatherReduced, multiTarget, otherModifier, friendship, opponentLevel, healthThreshold, source, state.trackers]);
 
   if (!state.trackers[source || '']) return <ErrorCard>No IV table with the name {source} exists.</ErrorCard>;
   if (!level) return <ErrorCard>The level attribute must be specified.</ErrorCard>;

--- a/components/route/DamageTable.tsx
+++ b/components/route/DamageTable.tsx
@@ -59,7 +59,7 @@ export const DamageTable: React.FC<DamageTableProps> = ({
   movePower,
   opponentStat,
   evolution = 0,
-  evs = 0,
+  evs = -1,
   combatStages = 0,
   effectiveness = 1,
   stab = 'false',
@@ -85,16 +85,18 @@ export const DamageTable: React.FC<DamageTableProps> = ({
   ), [tracker]);
 
   const confirmedNature = useMemo(() => ivRanges && tracker && calculatePossibleNature(ivRanges, tracker), [ivRanges, tracker]);
-  
+
   const offensiveStat: Stat = special === 'true' ? 'spAttack' : 'attack';
   const defensiveStat: Stat = special === 'true' ? 'spDefense' : 'defense';
   const relevantStat = offensive === 'true' ? offensiveStat : defensiveStat;
+
+  const trackerEvs = evs === -1 ? tracker && (tracker.evSegments[tracker.startingLevel]?.[Number(level)]?.[relevantStat] ?? 0) : evs;
 
   const rangeResults = useMemo(() => {
     const ranges = calculateRanges({
       level: Number(level || 0),
       baseStat: baseStats?.[relevantStat] ?? 0,
-      evs: Number(evs),
+      evs: Number(trackerEvs),
       combatStages: Number(combatStages),
       movePower: Number(movePower),
       typeEffectiveness: Number(effectiveness),


### PR DESCRIPTION
Damage tables will now use the EVs from the IV tracker for the given level when no specific EVs are specified. When EVs are specified for the damage table this feature will not be used.

It allows for more accurate damage tables, such as in the following routefile:
```
:::tracker{species=Starly1 baseStats="[[40, 55, 30, 30, 30, 60], [55, 75, 50, 40, 40, 80], [85, 120, 70, 50, 50, 100]]"}
20:
   20 -> 0, 0, 0, 0, 0, 0
:::

:::tracker{species=Starly2 baseStats="[[40, 55, 30, 30, 30, 60], [55, 75, 50, 40, 40, 80], [85, 120, 70, 50, 50, 100]]"}
20:
   20 -> 0, 0, 150, 0, 0, 0
:::

::damage[Starly 1 (0 evs)]{source="Starly1" level=20 offensive=false opponentLevel=20 opponentStat=30 movePower=30}
::damage[Starly 2 (150 evs)]{source="Starly2" level=20 offensive=false opponentLevel=20 opponentStat=30 movePower=30}
::damage[Starly 2 (evs overwritten to 200)]{source="Starly2" level=20 offensive=false opponentLevel=20 opponentStat=30 movePower=30 evs=200}
```