### PR TITLE
Route conditionals

### DIFF
--- a/components/route/ConditionalBlock.tsx
+++ b/components/route/ConditionalBlock.tsx
@@ -21,7 +21,7 @@ export const ConditionalBlock: React.FC<ConditionalBlockProps> = ({
   source,
   condition,
   level: rawLevel,
-  evolution: rawEvolution,
+  evolution: rawEvolution = '0',
   theme = 'borderless',
   children,
 }) => {

--- a/conditional-grammar.pegjs
+++ b/conditional-grammar.pegjs
@@ -3,36 +3,36 @@ Expression 'expression'
     return term
   }
 
-Term 'term' 
+Term 'term'
   = BinaryOrExpression
-  
+
 Literal
   = IntegerLiteral
-  
+
 Factor
   = "(" _ term: Term _ ")" { return term; }
   / StatExpression
-  
+
 Stat 'stat'
   = 'hp'
   / 'health'
   / 'atk'
   / 'attack'
-  / 'def'
   / 'defense'
-  / 'spa'
-  / 'spatk'
+  / 'def'
   / 'spattack'
+  / 'spatk'
+  / 'spa'
   / 'specialattack'
-  / 'spd'
-  / 'spdef'
   / 'spdefense'
+  / 'spdef'
+  / 'spd'
   / 'specialdefense'
-  / 'spe'
   / 'speed'
+  / 'spe'
   / 'startingLevel'
   / 'caughtLevel'
-  
+
 StatExpression 'statExpression'
   = _ stat: Stat _ '=' _ expression: Range {
     return {
@@ -52,7 +52,7 @@ BinaryOrExpression
         right: element[3]
       }), head);
     }
-   
+
 BinaryAndExpression
   = head: Factor
     tail:(_ '&&' _ BinaryAndExpression)* {
@@ -68,12 +68,12 @@ IntegerLiteral 'integer'
   = _ [0-9]+ {
     return parseInt(text(), 10);
   }
-  
+
 
 Range
-  = IVRange 
+  = IVRange
   / RangeSegment
-  
+
 IVRange = DeliminatedIVRange / InverseIVRange
 
 InverseIVRange
@@ -83,7 +83,7 @@ InverseIVRange
       inverse: true
 	};
   }
-  
+
 DeliminatedIVRange
 	= PositiveIVRange
 	/ '(' _ range: PositiveIVRange _ ')' { return range; }
@@ -98,14 +98,14 @@ PositiveIVRange 'ivRange'
       inverse: false,
     };
   }
-  
+
 IVRangeSegment = RangeSegment / '#' / 'x' / 'X'
 
 RangeSegment
  = BoundedRange
  / UnboundedRange
  / IntegerLiteral
- 
+
 UnboundedRange
   = value: IntegerLiteral _ operator: ('-' / '+') {
     return {
@@ -113,8 +113,8 @@ UnboundedRange
       value,
       operator,
     };
-  }  
- 
+  }
+
 BoundedRange
   = from: IntegerLiteral _ ('–' / '-' / '—') _ to: IntegerLiteral {
   	if (to < from) throw new Error('BoundedRange: upper limit must be greater than or equal to lower limit');
@@ -125,6 +125,6 @@ BoundedRange
       to,
     };
   }
-  
+
 _ "whitespace"
   = [ \t\n\r]*

--- a/directives/conditional-grammar.js
+++ b/directives/conditional-grammar.js
@@ -160,30 +160,30 @@ function peg$parse(input, options) {
       peg$c14 = peg$literalExpectation("atk", false),
       peg$c15 = "attack",
       peg$c16 = peg$literalExpectation("attack", false),
-      peg$c17 = "def",
-      peg$c18 = peg$literalExpectation("def", false),
-      peg$c19 = "defense",
-      peg$c20 = peg$literalExpectation("defense", false),
-      peg$c21 = "spa",
-      peg$c22 = peg$literalExpectation("spa", false),
+      peg$c17 = "defense",
+      peg$c18 = peg$literalExpectation("defense", false),
+      peg$c19 = "def",
+      peg$c20 = peg$literalExpectation("def", false),
+      peg$c21 = "spattack",
+      peg$c22 = peg$literalExpectation("spattack", false),
       peg$c23 = "spatk",
       peg$c24 = peg$literalExpectation("spatk", false),
-      peg$c25 = "spattack",
-      peg$c26 = peg$literalExpectation("spattack", false),
+      peg$c25 = "spa",
+      peg$c26 = peg$literalExpectation("spa", false),
       peg$c27 = "specialattack",
       peg$c28 = peg$literalExpectation("specialattack", false),
-      peg$c29 = "spd",
-      peg$c30 = peg$literalExpectation("spd", false),
+      peg$c29 = "spdefense",
+      peg$c30 = peg$literalExpectation("spdefense", false),
       peg$c31 = "spdef",
       peg$c32 = peg$literalExpectation("spdef", false),
-      peg$c33 = "spdefense",
-      peg$c34 = peg$literalExpectation("spdefense", false),
+      peg$c33 = "spd",
+      peg$c34 = peg$literalExpectation("spd", false),
       peg$c35 = "specialdefense",
       peg$c36 = peg$literalExpectation("specialdefense", false),
-      peg$c37 = "spe",
-      peg$c38 = peg$literalExpectation("spe", false),
-      peg$c39 = "speed",
-      peg$c40 = peg$literalExpectation("speed", false),
+      peg$c37 = "speed",
+      peg$c38 = peg$literalExpectation("speed", false),
+      peg$c39 = "spe",
+      peg$c40 = peg$literalExpectation("spe", false),
       peg$c41 = "startingLevel",
       peg$c42 = peg$literalExpectation("startingLevel", false),
       peg$c43 = "caughtLevel",
@@ -559,25 +559,25 @@ function peg$parse(input, options) {
             if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c17) {
+            if (input.substr(peg$currPos, 7) === peg$c17) {
               s0 = peg$c17;
-              peg$currPos += 3;
+              peg$currPos += 7;
             } else {
               s0 = peg$FAILED;
               if (peg$silentFails === 0) { peg$fail(peg$c18); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 7) === peg$c19) {
+              if (input.substr(peg$currPos, 3) === peg$c19) {
                 s0 = peg$c19;
-                peg$currPos += 7;
+                peg$currPos += 3;
               } else {
                 s0 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$c20); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c21) {
+                if (input.substr(peg$currPos, 8) === peg$c21) {
                   s0 = peg$c21;
-                  peg$currPos += 3;
+                  peg$currPos += 8;
                 } else {
                   s0 = peg$FAILED;
                   if (peg$silentFails === 0) { peg$fail(peg$c22); }
@@ -591,9 +591,9 @@ function peg$parse(input, options) {
                     if (peg$silentFails === 0) { peg$fail(peg$c24); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 8) === peg$c25) {
+                    if (input.substr(peg$currPos, 3) === peg$c25) {
                       s0 = peg$c25;
-                      peg$currPos += 8;
+                      peg$currPos += 3;
                     } else {
                       s0 = peg$FAILED;
                       if (peg$silentFails === 0) { peg$fail(peg$c26); }
@@ -607,9 +607,9 @@ function peg$parse(input, options) {
                         if (peg$silentFails === 0) { peg$fail(peg$c28); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 3) === peg$c29) {
+                        if (input.substr(peg$currPos, 9) === peg$c29) {
                           s0 = peg$c29;
-                          peg$currPos += 3;
+                          peg$currPos += 9;
                         } else {
                           s0 = peg$FAILED;
                           if (peg$silentFails === 0) { peg$fail(peg$c30); }
@@ -623,9 +623,9 @@ function peg$parse(input, options) {
                             if (peg$silentFails === 0) { peg$fail(peg$c32); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 9) === peg$c33) {
+                            if (input.substr(peg$currPos, 3) === peg$c33) {
                               s0 = peg$c33;
-                              peg$currPos += 9;
+                              peg$currPos += 3;
                             } else {
                               s0 = peg$FAILED;
                               if (peg$silentFails === 0) { peg$fail(peg$c34); }
@@ -639,17 +639,17 @@ function peg$parse(input, options) {
                                 if (peg$silentFails === 0) { peg$fail(peg$c36); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 3) === peg$c37) {
+                                if (input.substr(peg$currPos, 5) === peg$c37) {
                                   s0 = peg$c37;
-                                  peg$currPos += 3;
+                                  peg$currPos += 5;
                                 } else {
                                   s0 = peg$FAILED;
                                   if (peg$silentFails === 0) { peg$fail(peg$c38); }
                                 }
                                 if (s0 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 5) === peg$c39) {
+                                  if (input.substr(peg$currPos, 3) === peg$c39) {
                                     s0 = peg$c39;
-                                    peg$currPos += 5;
+                                    peg$currPos += 3;
                                   } else {
                                     s0 = peg$FAILED;
                                     if (peg$silentFails === 0) { peg$fail(peg$c40); }


### PR DESCRIPTION
1) Conditionals with stat ranges will now work without having the evolution specified. The evolution defaults to 0.
2) All stat literals are now parsed correctly.

Changes are reflected in the following routefile:
```
:::tracker{species=Starly baseStats="[[40, 55, 30, 30, 30, 60], [55, 75, 50, 40, 40, 80], [85, 120, 70, 50, 50, 100]]"}
9:
   10 -> 0, 0, 0, 2, 0, 0
:::

## Conditional stat range without evolution

:::if{source="Starly" level=9 condition="speed=15+" evolution=0}
speed stat range with evolution=0
:::

:::if{source="Starly" level=9 condition="speed=15+"}
speed stat range without evolution=0
:::

## All stat literals

:::if{source="Starly" condition="hp=(#/#/#)"}
"hp" works!
:::

:::if{source="Starly" condition="health=(#/#/#)"}
"health" works!
:::

:::if{source="Starly" condition="atk=(#/#/#)"}
"atk" works!
:::

:::if{source="Starly" condition="attack=(#/#/#)"}
"attack" works!
:::

:::if{source="Starly" condition="def=(#/#/#)"}
"def" works!
:::

:::if{source="Starly" condition="defense=(#/#/#)"}
"defense" works!
:::

:::if{source="Starly" condition="spa=(#/#/#)"}
"spa" works!
:::

:::if{source="Starly" condition="spatk=(#/#/#)"}
"spatk" works!
:::

:::if{source="Starly" condition="specialattack=(#/#/#)"}
"specialattack" works!
:::

:::if{source="Starly" condition="spd=(#/#/#)"}
"spe" works!
:::

:::if{source="Starly" condition="spe=(#/#/#)"}
"spd" works!
:::

:::if{source="Starly" condition="spdef=(#/#/#)"}
"spdef" works!
:::

:::if{source="Starly" condition="spdefense=(#/#/#)"}
"spdefense" works!
:::

:::if{source="Starly" condition="specialdefense=(#/#/#)"}
"specialdefense" works!
:::

:::if{source="Starly" condition="spe=(#/#/#)"}
"spe" works!
:::

:::if{source="Starly" condition="speed=(#/#/#)"}
"speed" works!
:::

:::if{source="Starly" condition="startingLevel=9"}
"startingLevel" works!
:::
```