### PR TITLE
add min-content on height of task names

### DIFF
--- a/pages/arceus/research.tsx
+++ b/pages/arceus/research.tsx
@@ -364,6 +364,7 @@ const TaskName = styled.div`
   display: flex;
   align-items: center;
   margin: 0 0.5rem;
+  height: min-content !important;
 `;
 
 const TaskValueSpacer = styled.div<{ columns: number }>`


### PR DESCRIPTION
Gave height to TaskNames of min-content. It spaces things out more but with the filter it should be fine.
#26 
![image](https://user-images.githubusercontent.com/7896916/206256827-395134a1-48f5-403c-90a0-0b57ad598083.png)
